### PR TITLE
Make and CMake support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,14 +52,6 @@
 		<plugins>
 			<plugin>
 				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-surefire-plugin</artifactId>
-				<version>2.8</version>
-				<configuration>
-					<useFile>false</useFile>
-					<printSummary>true</printSummary>
-				</configuration>
-			</plugin>
-
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,30 @@
   </pluginRepositories>
   
   <dependencies>
-
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-server</artifactId>
+			<version>7.2.2.v20101205</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-webapp</artifactId>
+			<version>7.2.2.v20101205</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.eclipse.jetty</groupId>
+			<artifactId>jetty-jsp-2.1</artifactId>
+			<version>7.2.2.v20101205</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.mortbay.jetty</groupId>
+			<artifactId>jsp-2.1-glassfish</artifactId>
+			<version>2.1.v20100127</version>
+			<scope>test</scope>
+		</dependency>
   </dependencies>
   
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -51,8 +51,6 @@
   <build>
 		<plugins>
 			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
         <version>2.0.2</version>

--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,17 @@
   </dependencies>
   
   <build>
-    <plugins>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-surefire-plugin</artifactId>
+				<version>2.8</version>
+				<configuration>
+					<useFile>false</useFile>
+					<printSummary>true</printSummary>
+				</configuration>
+			</plugin>
+
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>

--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
@@ -13,7 +13,7 @@ import hudson.tasks.Builder;
 import java.io.IOException;
 
 import jenkins.plugins.clangscanbuild.commands.BuildContextImpl;
-import jenkins.plugins.clangscanbuild.commands.ScanBuildCommand;
+import jenkins.plugins.clangscanbuild.commands.Command;
 
 import org.kohsuke.stapler.DataBoundConstructor;
 
@@ -39,9 +39,10 @@ public class ClangScanBuildBuilder extends Builder{
     private String clangInstallationName;
     private String xcodeProjectSubPath;
     private String workspace;
+    private String buildcommand;
     private String scheme;
     private String scanbuildargs;
-    private String xcodebuildargs;
+    private String buildargs;
 
     @DataBoundConstructor
     public ClangScanBuildBuilder( 
@@ -51,9 +52,10 @@ public class ClangScanBuildBuilder extends Builder{
     		String clangInstallationName,
     		String xcodeProjectSubPath,
     		String workspace,
+    		String buildcommand,
     		String scheme,
     		String scanbuildargs,
-                String xcodebuildargs){
+                String buildargs){
     	
         this.target = Util.fixEmptyAndTrim( target );
         this.targetSdk = Util.fixEmptyAndTrim( targetSdk );
@@ -61,9 +63,10 @@ public class ClangScanBuildBuilder extends Builder{
         this.clangInstallationName = Util.fixEmptyAndTrim( clangInstallationName );
         this.xcodeProjectSubPath = Util.fixEmptyAndTrim( xcodeProjectSubPath );
         this.workspace = Util.fixEmptyAndTrim( workspace );
+        this.buildcommand = Util.fixEmptyAndTrim( buildcommand );
         this.scheme = Util.fixEmptyAndTrim( scheme );
         this.scanbuildargs = Util.fixEmptyAndTrim( scanbuildargs );
-        this.xcodebuildargs = Util.fixEmptyAndTrim( xcodebuildargs );
+        this.buildargs = Util.fixEmptyAndTrim( buildargs );
     }
 
     public String getClangInstallationName(){
@@ -86,6 +89,10 @@ public class ClangScanBuildBuilder extends Builder{
 		return workspace;
 	}
 	
+	public String getBuildcommand(){
+		return buildcommand;
+	}
+	
 	public String getScheme(){
 		return scheme;
 	}
@@ -94,8 +101,8 @@ public class ClangScanBuildBuilder extends Builder{
 		return scanbuildargs;
 	}
 
-        public String getXcodebuildargs(){
-		return xcodebuildargs;
+        public String getBuildargs(){
+		return buildargs;
 	}
 
 	/**
@@ -129,12 +136,12 @@ public class ClangScanBuildBuilder extends Builder{
 		EnvVars env = build.getEnvironment(listener);
 		clangInstallation = clangInstallation.forEnvironment( env );
 		
-		ScanBuildCommand xcodebuild = new ScanBuildCommand();
+		Command xcodebuild = CommandFactory.get(getBuildcommand());
 		xcodebuild.setTarget( getTarget() );
 		xcodebuild.setTargetSdk( getTargetSdk() );
 		xcodebuild.setConfig( getConfig() );
 		xcodebuild.setAdditionalScanBuildArguments( getScanbuildargs() );
-		xcodebuild.setAdditionalXcodeBuildArguments( getXcodebuildargs() );
+		xcodebuild.setAdditionalBuildArguments( getBuildargs() );
 		xcodebuild.setClangOutputFolder( new FilePath( build.getWorkspace(), ClangScanBuildUtils.REPORT_OUTPUT_FOLDERNAME) );
 		xcodebuild.setWorkspace( getWorkspace() );
 		xcodebuild.setScheme( getScheme() );

--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
@@ -153,12 +153,40 @@ public class ClangScanBuildBuilder extends Builder{
 		}
 		
 		try {
-			String path = clangInstallation.getExecutable( launcher ) ;
+			String path = clangInstallation.getExecutable( launcher, "scan-build" ) ;
 			if( path == null ){
 				listener.fatalError( "Unable to locate 'scan-build' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
 				return false;
 			}
-			xcodebuild.setClangScanBuildPath( path );
+			xcodebuild.setClangScanExecutable( path );
+			
+			String analyzer = clangInstallation.getExecutable( launcher, "ccc-analyzer" ) ;
+			if( analyzer == null ){
+				listener.fatalError( "Unable to locate 'ccc-analyzer' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
+				return false;
+			}
+			xcodebuild.setClangAnalyzerExecutable( analyzer );
+			
+			String xxanalyzer = clangInstallation.getExecutable( launcher, "c++-analyzer" ) ;
+			if( xxanalyzer == null ){
+				listener.fatalError( "Unable to locate 'c++-analyzer' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
+				return false;
+			}
+			xcodebuild.setClangXXAnalyzerExecutable( xxanalyzer );
+
+			String clang = clangInstallation.getExecutable( launcher, "clang" ) ;
+			if( clang == null ){
+				listener.fatalError( "Unable to locate 'clang' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
+				return false;
+			}
+			xcodebuild.setClangCompilerExecutable( clang );
+			
+			String clangxx = clangInstallation.getExecutable( launcher, "clang++" ) ;
+			if( clangxx == null ){
+				listener.fatalError( "Unable to locate 'clang++' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
+				return false;
+			}
+			xcodebuild.setClangXXCompilerExecutable( clangxx );
 		} catch ( Exception e) {
 			listener.fatalError( "Unable to locate 'scan-build' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config.", e );
 			return false;

--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
@@ -158,6 +158,7 @@ public class ClangScanBuildBuilder extends Builder{
 				listener.fatalError( "Unable to locate 'scan-build' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
 				return false;
 			}
+			listener.getLogger().println("Using 'scan-build' " + path);
 			xcodebuild.setClangScanExecutable( path );
 			
 			String analyzer = clangInstallation.getExecutable( launcher, "ccc-analyzer" ) ;
@@ -165,6 +166,7 @@ public class ClangScanBuildBuilder extends Builder{
 				listener.fatalError( "Unable to locate 'ccc-analyzer' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
 				return false;
 			}
+			listener.getLogger().println("Using 'ccc-analyzer' " + analyzer);
 			xcodebuild.setClangAnalyzerExecutable( analyzer );
 			
 			String xxanalyzer = clangInstallation.getExecutable( launcher, "c++-analyzer" ) ;
@@ -172,6 +174,7 @@ public class ClangScanBuildBuilder extends Builder{
 				listener.fatalError( "Unable to locate 'c++-analyzer' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
 				return false;
 			}
+			listener.getLogger().println("Using 'c++-analyzer' " + xxanalyzer);
 			xcodebuild.setClangXXAnalyzerExecutable( xxanalyzer );
 
 			String clang = clangInstallation.getExecutable( launcher, "clang" ) ;
@@ -179,6 +182,7 @@ public class ClangScanBuildBuilder extends Builder{
 				listener.fatalError( "Unable to locate 'clang' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
 				return false;
 			}
+			listener.getLogger().println("Using 'clang' " + clang);
 			xcodebuild.setClangCompilerExecutable( clang );
 			
 			String clangxx = clangInstallation.getExecutable( launcher, "clang++" ) ;
@@ -186,6 +190,7 @@ public class ClangScanBuildBuilder extends Builder{
 				listener.fatalError( "Unable to locate 'clang++' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config." );
 				return false;
 			}
+			listener.getLogger().println("Using 'clang++' " + clangxx);
 			xcodebuild.setClangXXCompilerExecutable( clangxx );
 		} catch ( Exception e) {
 			listener.fatalError( "Unable to locate 'scan-build' within '" + clangInstallation.getHome() + "' as configured in clang installation named '" + clangInstallation.getName() + "' in the global config.", e );

--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildDescriptor.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildDescriptor.java
@@ -7,11 +7,13 @@ import hudson.tasks.BuildStepDescriptor;
 import hudson.tasks.Builder;
 import hudson.tools.ToolInstallation;
 import hudson.util.FormValidation;
+import hudson.util.ListBoxModel;
 
 import java.io.IOException;
 
 import javax.servlet.ServletException;
 
+import jenkins.plugins.clangscanbuild.ClangScanBuildToolInstallation.ClangStaticAnalyzerToolDescriptor;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.QueryParameter;
@@ -43,7 +45,7 @@ public class ClangScanBuildDescriptor extends BuildStepDescriptor<Builder>{
     public ClangScanBuildToolInstallation.ClangStaticAnalyzerToolDescriptor getToolDescriptor(){
         return ToolInstallation.all().get( ClangScanBuildToolInstallation.ClangStaticAnalyzerToolDescriptor.class );
     }
-    
+
     public ClangScanBuildToolInstallation[] getInstallations(){
         return installations;
     }
@@ -102,5 +104,14 @@ public class ClangScanBuildDescriptor extends BuildStepDescriptor<Builder>{
     public boolean isApplicable( @SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobType ){
         return FreeStyleProject.class.isAssignableFrom( jobType );
     }
-    
+
+    public ListBoxModel doFillBuildcommandItems() {
+    	ListBoxModel items = new ListBoxModel();
+    	String [] tools = CommandFactory.getToolchains();
+    	
+    	for (String s : tools) {
+    		items.add(s, s);
+    	}
+    	return items;
+    }
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildToolInstallation.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildToolInstallation.java
@@ -55,6 +55,24 @@ public class ClangScanBuildToolInstallation extends ToolInstallation implements 
     	this.tool = tool;
     }
     
+    private static File findExecutableOnPath(String executableName)  
+    {  
+        String systemPath = System.getenv("PATH");  
+        String[] pathDirs = systemPath.split(File.pathSeparator);  
+   
+        File fullyQualifiedExecutable = null;  
+        for (String pathDir : pathDirs)  
+        {  
+            File file = new File(pathDir, executableName);  
+            if (file.isFile())  
+            {  
+                fullyQualifiedExecutable = file;  
+                break;  
+            }  
+        }  
+        return fullyQualifiedExecutable;  
+    }
+    
     public String getExecutable( Launcher launcher, String tool ) throws IOException, InterruptedException {
     	setTool(tool);
     	
@@ -65,6 +83,11 @@ public class ClangScanBuildToolInstallation extends ToolInstallation implements 
 			public String call() throws IOException {
                 File scanbuild = new File( getHome(), getTool() );
                 if( scanbuild.exists() ) return scanbuild.getPath();
+                
+                /* Fall back to environment and check, if the tool can be found... */
+                scanbuild = findExecutableOnPath(getTool());
+                if( scanbuild.exists() ) return scanbuild.getPath();
+                
                 return null;
             }
         	

--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildToolInstallation.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildToolInstallation.java
@@ -25,6 +25,7 @@ import org.kohsuke.stapler.QueryParameter;
 public class ClangScanBuildToolInstallation extends ToolInstallation implements NodeSpecific<ClangScanBuildToolInstallation>, EnvironmentSpecific<ClangScanBuildToolInstallation>{
 
 	private static final long serialVersionUID = -2485377492741518511L;
+	private String tool;
 	
 	@DataBoundConstructor
     public ClangScanBuildToolInstallation( 
@@ -46,13 +47,23 @@ public class ClangScanBuildToolInstallation extends ToolInstallation implements 
         }
     }
 
-    public String getExecutable( Launcher launcher ) throws IOException, InterruptedException {
+    private String getTool() {
+    	return tool;
+    }
+    
+    private void setTool(String tool) {
+    	this.tool = tool;
+    }
+    
+    public String getExecutable( Launcher launcher, String tool ) throws IOException, InterruptedException {
+    	setTool(tool);
+    	
         return launcher.getChannel().call( new Callable<String,IOException>() {
 
 			private static final long serialVersionUID = 5437036131007277280L;
 
 			public String call() throws IOException {
-                File scanbuild = new File( getHome(), "scan-build" );
+                File scanbuild = new File( getHome(), getTool() );
                 if( scanbuild.exists() ) return scanbuild.getPath();
                 return null;
             }

--- a/src/main/java/jenkins/plugins/clangscanbuild/CommandFactory.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/CommandFactory.java
@@ -1,0 +1,16 @@
+package jenkins.plugins.clangscanbuild;
+
+import jenkins.plugins.clangscanbuild.commands.Command;
+import jenkins.plugins.clangscanbuild.commands.ScanBuildCommand;
+import jenkins.plugins.clangscanbuild.commands.ScanMakeBuildCommand;
+
+public final class CommandFactory {
+
+	public static Command get(String cmd){
+		System.err.println("Command requested: '" + cmd + "'");
+		//if (cmd == "make")
+			return new ScanMakeBuildCommand();
+		
+		//return new ScanBuildCommand();
+	}
+}

--- a/src/main/java/jenkins/plugins/clangscanbuild/CommandFactory.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/CommandFactory.java
@@ -7,13 +7,20 @@ import jenkins.plugins.clangscanbuild.commands.ScanMakeBuildCommand;
 
 public final class CommandFactory {
 
-	public static Command get(String cmd){
+	private static final String[] toolchains = {"XCode", "make", "CMake"};
 	
-		if (cmd.startsWith("make"))
+	public static Command get(String cmd){
+
+		System.err.println("Using build command " + cmd);
+		if (cmd.toLowerCase().startsWith("make"))
 			return new ScanMakeBuildCommand();
-		if (cmd.startsWith("cmake"))
+		if (cmd.toLowerCase().startsWith("cmake"))
 			return new ScanCMakeBuildCommand();
 		
 		return new ScanBuildCommand();
+	}
+	
+	public static String[] getToolchains() {
+		return toolchains;
 	}
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/CommandFactory.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/CommandFactory.java
@@ -2,15 +2,18 @@ package jenkins.plugins.clangscanbuild;
 
 import jenkins.plugins.clangscanbuild.commands.Command;
 import jenkins.plugins.clangscanbuild.commands.ScanBuildCommand;
+import jenkins.plugins.clangscanbuild.commands.ScanCMakeBuildCommand;
 import jenkins.plugins.clangscanbuild.commands.ScanMakeBuildCommand;
 
 public final class CommandFactory {
 
 	public static Command get(String cmd){
-		System.err.println("Command requested: '" + cmd + "'");
-		//if (cmd == "make")
+	
+		if (cmd.startsWith("make"))
 			return new ScanMakeBuildCommand();
+		if (cmd.startsWith("cmake"))
+			return new ScanCMakeBuildCommand();
 		
-		//return new ScanBuildCommand();
+		return new ScanBuildCommand();
 	}
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction.java
@@ -4,17 +4,13 @@ import hudson.FilePath;
 import hudson.model.Action;
 import hudson.model.ModelObject;
 import hudson.model.AbstractBuild;
-import hudson.util.FormValidation;
 
 import java.io.IOException;
 import java.util.regex.Pattern;
 
-import javax.servlet.ServletException;
-
 import jenkins.plugins.clangscanbuild.ClangScanBuildUtils;
 import jenkins.plugins.clangscanbuild.history.ClangScanBuildBugSummary;
 
-import org.kohsuke.stapler.QueryParameter;
 import org.kohsuke.stapler.StaplerProxy;
 import org.kohsuke.stapler.StaplerRequest;
 import org.kohsuke.stapler.StaplerResponse;

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/BuildContext.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/BuildContext.java
@@ -22,7 +22,7 @@ public interface BuildContext {
 	 * Returns workspace location of current executing build
 	 */
 	public FilePath getWorkspace();
-	
+
 	/**
 	 * This method starts a process and will not return control until
 	 * either the process is complete or the process is interrupted.  

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/BuildContext.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/BuildContext.java
@@ -1,5 +1,7 @@
 package jenkins.plugins.clangscanbuild.commands;
 
+import java.util.List;
+
 import hudson.FilePath;
 import hudson.util.ArgumentListBuilder;
 
@@ -36,5 +38,4 @@ public interface BuildContext {
 	 * Logs a message to the build listener.
 	 */
 	public void log( String message );
-	
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/BuildContextImpl.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/BuildContextImpl.java
@@ -78,5 +78,4 @@ public class BuildContextImpl implements BuildContext{
 		
 		return 1; // ERROR
 	}
-
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/BuildContextImpl.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/BuildContextImpl.java
@@ -10,6 +10,7 @@ import hudson.util.ArgumentListBuilder;
 import hudson.model.TaskListener;
 
 import java.io.IOException;
+import java.util.List;
 
 @SuppressWarnings("rawtypes")
 public class BuildContextImpl implements BuildContext{
@@ -48,7 +49,7 @@ public class BuildContextImpl implements BuildContext{
 	public FilePath getBuildFolder() {
 		return new FilePath( build.getRootDir() );
 	}
-
+	
 	@Override
 	public int waitForProcess( FilePath presentWorkingDirectory, ArgumentListBuilder command ){
 

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/Command.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/Command.java
@@ -22,7 +22,15 @@ public interface Command {
 	
 	public void setClangOutputFolder(FilePath directory);
 
-	public void setClangScanBuildPath(String path);
+	public void setClangScanExecutable(String path);
 
 	public void setAdditionalBuildArguments(String buildargs);
+	
+	public void setClangAnalyzerExecutable(String tool);
+
+	public void setClangXXAnalyzerExecutable(String tool);
+
+	public void setClangCompilerExecutable(String tool);
+
+	public void setClangXXCompilerExecutable(String tool);
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/Command.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/Command.java
@@ -1,7 +1,28 @@
 package jenkins.plugins.clangscanbuild.commands;
 
+import hudson.FilePath;
+
 public interface Command {
 	
 	public int execute( BuildContext context ) throws Exception;
 
+	public void setTarget(String target);
+	
+	public void setProjectDirectory(FilePath directory);
+	
+	public void setConfig(String cfg);
+
+	public void setWorkspace(String workspace);
+
+	public void setScheme(String scheme);
+
+	public void setTargetSdk(String sdk);
+	
+	public void setAdditionalScanBuildArguments(String args);
+	
+	public void setClangOutputFolder(FilePath directory);
+
+	public void setClangScanBuildPath(String path);
+
+	public void setAdditionalBuildArguments(String buildargs);
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
@@ -43,8 +43,6 @@ public abstract class ScanBasicCommand implements Command {
 
 		args.add("-o"); // output folder
 		args.add(escapeSpacesInPath(clangOutputFolder.getRemote()));
-		if (!getClangCompilerExecutable().isEmpty())
-			args.add("--use-analyzer", getClangCompilerExecutable());
 
 		String additionalArgs = getAdditionalScanBuildArguments();
 		if (isNotBlank(additionalArgs)) {

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
@@ -39,7 +39,8 @@ public abstract class ScanBasicCommand implements Command {
 
 		args.add("-o"); // output folder
 		args.add(escapeSpacesInPath(clangOutputFolder.getRemote()));
-		args.add("--use-analyzer", getClangCompilerExecutable());
+		if (!getClangCompilerExecutable().isEmpty())
+			args.add("--use-analyzer", getClangCompilerExecutable());
 
 		String additionalArgs = getAdditionalScanBuildArguments();
 		if (isNotBlank(additionalArgs)) {

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
@@ -17,10 +17,10 @@ public abstract class ScanBasicCommand implements Command {
 	protected FilePath clangOutputFolder;
 	protected String additionalScanBuildArguments; // Passed directly to shell
 	protected String additionalBuildArguments; // Passed directly to shel
-	protected String clangAnalyzerExecutable;
-	protected String clangXXAnalyzerExecutable;
-	protected String clangCompiler;
-	protected String clangXXCompiler;
+	protected String clangAnalyzerExecutable = "";
+	protected String clangXXAnalyzerExecutable = "";
+	protected String clangCompiler = "";
+	protected String clangXXCompiler = "";
 
 	ArgumentListBuilder executeCommon(BuildContext context) throws Exception {
 		if (clangOutputFolder.exists()) {

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
@@ -17,6 +17,10 @@ public abstract class ScanBasicCommand implements Command {
 	protected FilePath clangOutputFolder;
 	protected String additionalScanBuildArguments; // Passed directly to shell
 	protected String additionalBuildArguments; // Passed directly to shel
+	protected String clangAnalyzerExecutable;
+	protected String clangXXAnalyzerExecutable;
+	protected String clangCompiler;
+	protected String clangXXCompiler;
 
 	ArgumentListBuilder executeCommon(BuildContext context) throws Exception {
 		if (clangOutputFolder.exists()) {
@@ -30,7 +34,7 @@ public abstract class ScanBasicCommand implements Command {
 		}
 
 		ArgumentListBuilder args = new ArgumentListBuilder();
-			
+
 		args.add(getClangScanBuildExecutable());
 
 		args.add("-k"); // keep going on failure
@@ -103,7 +107,7 @@ public abstract class ScanBasicCommand implements Command {
 	}
 
 	@Override
-	public void setClangScanBuildPath(String path) {
+	public void setClangScanExecutable(String path) {
 		clangScanBuildPath = path;
 	}
 
@@ -111,21 +115,23 @@ public abstract class ScanBasicCommand implements Command {
 	public void setAdditionalBuildArguments(String buildargs) {
 		additionalBuildArguments = buildargs;
 	}
-	
-	protected boolean isBlank( String value ){
-		if( value == null ) return true;
+
+	protected boolean isBlank(String value) {
+		if (value == null)
+			return true;
 		return value.trim().length() <= 0;
 	}
-	
-	protected String escapeSpacesInPath( String path ){
-		if( path == null ) return "";
-		return path.replaceAll( " ", "\\ " );
+
+	protected String escapeSpacesInPath(String path) {
+		if (path == null)
+			return "";
+		return path.replaceAll(" ", "\\ ");
 	}
-	
-	protected boolean isNotBlank( String value ){
-		return !isBlank( value );
+
+	protected boolean isNotBlank(String value) {
+		return !isBlank(value);
 	}
-	
+
 	public String getTargetSdk() {
 		return targetSdk;
 	}
@@ -138,20 +144,38 @@ public abstract class ScanBasicCommand implements Command {
 		return config;
 	}
 
+	public void setClangAnalyzerExecutable(String tool) {
+		clangAnalyzerExecutable = tool;
+	}
+
+	public void setClangXXAnalyzerExecutable(String tool) {
+		clangXXAnalyzerExecutable = tool;
+	}
+
+	public void setClangCompilerExecutable(String tool) {
+		clangCompiler = tool;
+	}
+
+	public void setClangXXCompilerExecutable(String tool) {
+		clangXXCompiler = tool;
+	}
+
+	public String getClangAnalyzerExecutable() {
+		return clangAnalyzerExecutable;
+	}
+
+	public String getClangXXAnalyzerExecutable() {
+		return clangXXAnalyzerExecutable;
+	}
+
 	public String getClangCompilerExecutable() {
-		File base = new File(clangScanBuildPath);
-		File clang = new File(base.getParent(), "clang");
-		
-		return clang.getAbsolutePath();
+		return clangCompiler;
 	}
-	
+
 	public String getClangXXCompilerExecutable() {
-		File base = new File(clangScanBuildPath);
-		File clang = new File(base.getParent(), "clang++");
-		
-		return clang.getAbsolutePath();
+		return clangXXCompiler;
 	}
-	
+
 	public String getClangScanBuildExecutable() {
 		return clangScanBuildPath;
 	}
@@ -179,7 +203,7 @@ public abstract class ScanBasicCommand implements Command {
 	public String getAdditionalBuildArguments() {
 		return additionalBuildArguments;
 	}
-	
+
 	protected static void deleteFolder(File folder) {
 		File[] files = folder.listFiles();
 		if (files != null) {

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
@@ -178,4 +178,18 @@ public abstract class ScanBasicCommand implements Command {
 	public String getAdditionalBuildArguments() {
 		return additionalBuildArguments;
 	}
+	
+	protected static void deleteFolder(File folder) {
+		File[] files = folder.listFiles();
+		if (files != null) {
+			for (File f : files) {
+				if (f.isDirectory()) {
+					deleteFolder(f);
+				} else {
+					f.delete();
+				}
+			}
+		}
+		folder.delete();
+	}
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
@@ -1,0 +1,164 @@
+package jenkins.plugins.clangscanbuild.commands;
+
+import hudson.FilePath;
+import hudson.util.ArgumentListBuilder;
+
+public abstract class ScanBasicCommand implements Command {
+
+	protected String target;
+	protected String config = "Debug";
+	protected String workspace;
+	protected String scheme;
+	protected String targetSdk;
+	protected String clangScanBuildPath;
+	protected FilePath projectDirectory;
+	protected FilePath clangOutputFolder;
+	protected String additionalScanBuildArguments; // Passed directly to shell
+	protected String additionalBuildArguments; // Passed directly to shel
+
+	ArgumentListBuilder executeCommon(BuildContext context) throws Exception {
+		if (clangOutputFolder.exists()) {
+			// this should never happen because this folder is in the build
+			// directory - famous last words
+			context.log("Deleting '" + getClangOutputFolder().getRemote()
+					+ "' contents from previous build.");
+			clangOutputFolder.deleteContents();
+		} else {
+			clangOutputFolder.mkdirs();
+		}
+
+		ArgumentListBuilder args = new ArgumentListBuilder();
+			
+		args.add(getClangScanBuildPath());
+
+		args.add("-k"); // keep going on failure
+		args.add("-v"); // verbose
+		args.add("-v"); // even more verbose
+
+		args.add("-o"); // output folder
+		args.add(escapeSpacesInPath(clangOutputFolder.getRemote()));
+
+		String additionalArgs = getAdditionalScanBuildArguments();
+		if (isNotBlank(additionalArgs)) {
+			// This is a hack. I can't call the standard
+			// ArgumentListBuilder.add() method because it checks for spaces
+			// with-in
+			// the arg and quotes the arg if a space exists. Since user's can
+			// pass commands like
+			// '--use-cc=`which clang`' or multiple commands...we cannot allow
+			// the quotes to be
+			// inserted when spaces exist. The
+			// ArgumentListBuilder.addTokenized() splits the arg on spaces and
+			// adds each piece
+			// which ends up reinserting the spaces when the command is
+			// assembled.
+			args.addTokenized(additionalArgs);
+		}
+
+		return args;
+	}
+
+	@Override
+	public void setTarget(String target) {
+		this.target = target;
+	}
+
+	@Override
+	public void setProjectDirectory(FilePath directory) {
+		projectDirectory = directory;
+	}
+
+	@Override
+	public void setConfig(String cfg) {
+		config = cfg;
+	}
+
+	@Override
+	public void setWorkspace(String workspace) {
+		this.workspace = workspace;
+	}
+
+	@Override
+	public void setScheme(String scheme) {
+		this.scheme = scheme;
+	}
+
+	@Override
+	public void setTargetSdk(String sdk) {
+		targetSdk = sdk;
+	}
+
+	@Override
+	public void setAdditionalScanBuildArguments(String args) {
+		additionalScanBuildArguments = args;
+	}
+
+	@Override
+	public void setClangOutputFolder(FilePath directory) {
+		clangOutputFolder = directory;
+	}
+
+	@Override
+	public void setClangScanBuildPath(String path) {
+		clangScanBuildPath = path;
+	}
+
+	@Override
+	public void setAdditionalBuildArguments(String buildargs) {
+		additionalBuildArguments = buildargs;
+	}
+	
+	protected boolean isBlank( String value ){
+		if( value == null ) return true;
+		return value.trim().length() <= 0;
+	}
+	
+	protected String escapeSpacesInPath( String path ){
+		if( path == null ) return "";
+		return path.replaceAll( " ", "\\ " );
+	}
+	
+	protected boolean isNotBlank( String value ){
+		return !isBlank( value );
+	}
+	
+	public String getTargetSdk() {
+		return targetSdk;
+	}
+
+	public String getTarget() {
+		return target;
+	}
+
+	public String getConfig() {
+		return config;
+	}
+
+	public String getClangScanBuildPath() {
+		return clangScanBuildPath;
+	}
+
+	public FilePath getProjectDirectory() {
+		return projectDirectory;
+	}
+
+	public FilePath getClangOutputFolder() {
+		return clangOutputFolder;
+	}
+
+	public String getWorkspace() {
+		return workspace;
+	}
+
+	public String getScheme() {
+		return scheme;
+	}
+
+	public String getAdditionalScanBuildArguments() {
+		return additionalScanBuildArguments;
+	}
+
+	public String getAdditionalBuildArguments() {
+		return additionalBuildArguments;
+	}
+}

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBasicCommand.java
@@ -1,5 +1,7 @@
 package jenkins.plugins.clangscanbuild.commands;
 
+import java.io.File;
+
 import hudson.FilePath;
 import hudson.util.ArgumentListBuilder;
 
@@ -29,7 +31,7 @@ public abstract class ScanBasicCommand implements Command {
 
 		ArgumentListBuilder args = new ArgumentListBuilder();
 			
-		args.add(getClangScanBuildPath());
+		args.add(getClangScanBuildExecutable());
 
 		args.add("-k"); // keep going on failure
 		args.add("-v"); // verbose
@@ -37,6 +39,7 @@ public abstract class ScanBasicCommand implements Command {
 
 		args.add("-o"); // output folder
 		args.add(escapeSpacesInPath(clangOutputFolder.getRemote()));
+		args.add("--use-analyzer", getClangCompilerExecutable());
 
 		String additionalArgs = getAdditionalScanBuildArguments();
 		if (isNotBlank(additionalArgs)) {
@@ -134,7 +137,21 @@ public abstract class ScanBasicCommand implements Command {
 		return config;
 	}
 
-	public String getClangScanBuildPath() {
+	public String getClangCompilerExecutable() {
+		File base = new File(clangScanBuildPath);
+		File clang = new File(base.getParent(), "clang");
+		
+		return clang.getAbsolutePath();
+	}
+	
+	public String getClangXXCompilerExecutable() {
+		File base = new File(clangScanBuildPath);
+		File clang = new File(base.getParent(), "clang++");
+		
+		return clang.getAbsolutePath();
+	}
+	
+	public String getClangScanBuildExecutable() {
 		return clangScanBuildPath;
 	}
 

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBuildCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanBuildCommand.java
@@ -1,56 +1,13 @@
 package jenkins.plugins.clangscanbuild.commands;
 
-import hudson.FilePath;
 import hudson.util.ArgumentListBuilder;
 import jenkins.plugins.clangscanbuild.CommandExecutor;
 
-public class ScanBuildCommand implements Command{
-	
-	private String clangScanBuildPath;
-	private FilePath projectDirectory;
-    private FilePath clangOutputFolder;
-    
-    private String targetSdk;
-    private String config = "Debug";
-    
-    private String target;
-    
-    private String additionalScanBuildArguments; // Passed directly to shell
-
-    private String additionalXcodeBuildArguments; // Passed directly to shell
-
-    private String workspace;
-    private String scheme;
+public class ScanBuildCommand extends ScanBasicCommand {
 	
 	public int execute( BuildContext context ) throws Exception {
 
-		if( clangOutputFolder.exists() ){
-			// this should never happen because this folder is in the build directory - famous last words
-			context.log( "Deleting '" + getClangOutputFolder().getRemote() + "' contents from previous build." );
-			clangOutputFolder.deleteContents();
-		}else{
-			clangOutputFolder.mkdirs();
-		}
-
-		ArgumentListBuilder args = new ArgumentListBuilder();
-		args.add( getClangScanBuildPath() );
-		
-		args.add( "-k" ); // keep going on failure
-		args.add( "-v" ); // verbose
-		args.add( "-v" ); // even more verbose
-		
-		args.add( "-o" ); // output folder
-		args.add( escapeSpacesInPath( clangOutputFolder.getRemote() ) );
-		
-		String additionalArgs = getAdditionalScanBuildArguments();
-		if( isNotBlank( additionalArgs ) ){
-			// This is a hack.  I can't call the standard ArgumentListBuilder.add() method because it checks for spaces with-in
-			// the arg and quotes the arg if a space exists.  Since user's can pass commands like
-			// '--use-cc=`which clang`' or multiple commands...we cannot allow the quotes to be 
-			// inserted when spaces exist.  The ArgumentListBuilder.addTokenized() splits the arg on spaces and adds each piece 
-			// which ends up reinserting the spaces when the command is assembled.
-			args.addTokenized( additionalArgs );
-		}
+		ArgumentListBuilder args = executeCommon(context);
 		
 		args.add( "xcodebuild" );
 		
@@ -78,7 +35,7 @@ public class ScanBuildCommand implements Command{
 		args.add( "clean" ); // clang scan requires a clean
 		args.add( "build" );
                 
-		String additionalXcodeBuildArgs = getAdditionalXcodeBuildArguments();
+		String additionalXcodeBuildArgs = getAdditionalBuildArguments();
 		if( isNotBlank( additionalXcodeBuildArgs ) ){
 			// This is a hack.  I can't call the standard ArgumentListBuilder.add() method because it checks for spaces with-in
 			// the arg and quotes the arg if a space exists.  Since user's can pass commands like
@@ -99,99 +56,4 @@ public class ScanBuildCommand implements Command{
 		return rc;
 
 	}
-
-	private boolean isBlank( String value ){
-		if( value == null ) return true;
-		return value.trim().length() <= 0;
-	}
-	
-	private String escapeSpacesInPath( String path ){
-		if( path == null ) return "";
-		return path.replaceAll( " ", "\\ " );
-	}
-	
-	private boolean isNotBlank( String value ){
-		return !isBlank( value );
-	}
-	
-	public String getTargetSdk() {
-		return targetSdk;
-	}
-
-	public void setTargetSdk(String targetSdk) {
-		this.targetSdk = targetSdk;
-	}
-
-	public String getTarget() {
-		return target;
-	}
-
-	public void setTarget(String target) {
-		this.target = target;
-	}
-
-	public String getConfig() {
-		return config;
-	}
-
-	public void setConfig(String config) {
-		this.config = config;
-	}
-
-	public String getClangScanBuildPath() {
-		return clangScanBuildPath;
-	}
-
-	public void setClangScanBuildPath(String clangScanBuildPath) {
-		this.clangScanBuildPath = clangScanBuildPath;
-	}
-
-	public FilePath getProjectDirectory() {
-		return projectDirectory;
-	}
-
-	public void setProjectDirectory(FilePath projectDirectory) {
-		this.projectDirectory = projectDirectory;
-	}
-
-	public FilePath getClangOutputFolder() {
-		return clangOutputFolder;
-	}
-
-	public void setClangOutputFolder(FilePath clangOutputFolder) {
-		this.clangOutputFolder = clangOutputFolder;
-	}
-
-	public String getWorkspace() {
-		return workspace;
-	}
-
-	public void setWorkspace(String workspace) {
-		this.workspace = workspace;
-	}
-
-	public String getScheme() {
-		return scheme;
-	}
-
-	public void setScheme(String scheme) {
-		this.scheme = scheme;
-	}
-
-	public String getAdditionalScanBuildArguments() {
-		return additionalScanBuildArguments;
-	}
-
-	public void setAdditionalScanBuildArguments(String additionalScanBuildArguments) {
-		this.additionalScanBuildArguments = additionalScanBuildArguments;
-	}
-
-        public String getAdditionalXcodeBuildArguments() {
-		return additionalXcodeBuildArguments;
-	}
-
-	public void setAdditionalXcodeBuildArguments(String additionalXcodeBuildArguments) {
-		this.additionalXcodeBuildArguments = additionalXcodeBuildArguments;
-	}
-
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanCMakeBuildCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanCMakeBuildCommand.java
@@ -13,27 +13,17 @@ public class ScanCMakeBuildCommand extends ScanBasicCommand {
 		return "cmake";
 	}
 
-	private static void deleteFolder(File folder) {
-		File[] files = folder.listFiles();
-		if (files != null) {
-			for (File f : files) {
-				if (f.isDirectory()) {
-					deleteFolder(f);
-				} else {
-					f.delete();
-				}
-			}
-		}
-		folder.delete();
-	}
-
 	public int execute(BuildContext context) throws Exception {
 
-		/* Remove old build folder... */
 		File build = new File(getProjectDirectory().toURI());
-		if (build.exists())
-			deleteFolder(build);
-		build.mkdirs();
+		File src = new File(context.getWorkspace().getRemote(), getWorkspace());
+
+		/* Remove old build folder, but only if we build out of tree. */
+		if (!src.equals(build)) {
+			if (build.exists())
+				deleteFolder(build);
+			build.mkdirs();
+		}
 
 		/* Create the CMake configuration for the target. */
 		ArgumentListBuilder prepargs = new ArgumentListBuilder();
@@ -43,8 +33,6 @@ public class ScanCMakeBuildCommand extends ScanBasicCommand {
 		 * Build the CMake generation string. Use separate add for arguments, as
 		 * they may contain spaces and additional quoting is not desired.
 		 */
-
-		File src = new File(context.getWorkspace().getRemote(), getWorkspace());
 		prepargs.add("-G" + getTargetSdk());
 		prepargs.add("-B" + getProjectDirectory().getRemote());
 		prepargs.add("-H" + src.getAbsolutePath());

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanCMakeBuildCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanCMakeBuildCommand.java
@@ -36,8 +36,8 @@ public class ScanCMakeBuildCommand extends ScanBasicCommand {
 		prepargs.add("-G" + getTargetSdk());
 		prepargs.add("-B" + getProjectDirectory().getRemote());
 		prepargs.add("-H" + src.getAbsolutePath());
-		prepargs.add("-DCMAKE_C_COMPILER=" + getClangCompilerExecutable());
-		prepargs.add("-DCMAKE_CXX_COMPILER=" + getClangXXCompilerExecutable());
+		prepargs.add("-DCMAKE_C_COMPILER=" + getClangAnalyzerExecutable());
+		prepargs.add("-DCMAKE_CXX_COMPILER=" + getClangXXAnalyzerExecutable());
 
 		String additionalBuildArgs = getAdditionalBuildArguments();
 		if (isNotBlank(additionalBuildArgs)) {

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanCMakeBuildCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanCMakeBuildCommand.java
@@ -1,0 +1,100 @@
+package jenkins.plugins.clangscanbuild.commands;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.List;
+
+import hudson.util.ArgumentListBuilder;
+import jenkins.plugins.clangscanbuild.CommandExecutor;
+
+public class ScanCMakeBuildCommand extends ScanBasicCommand {
+
+	private String getCMakeExecutable() {
+		return "cmake";
+	}
+
+	private static void deleteFolder(File folder) {
+		File[] files = folder.listFiles();
+		if (files != null) {
+			for (File f : files) {
+				if (f.isDirectory()) {
+					deleteFolder(f);
+				} else {
+					f.delete();
+				}
+			}
+		}
+		folder.delete();
+	}
+
+	public int execute(BuildContext context) throws Exception {
+
+		/* Remove old build folder... */
+		File build = new File(getProjectDirectory().toURI());
+		if (build.exists())
+			deleteFolder(build);
+		build.mkdirs();
+
+		/* Create the CMake configuration for the target. */
+		ArgumentListBuilder prepargs = new ArgumentListBuilder();
+		prepargs.add(getCMakeExecutable());
+
+		/*
+		 * Build the CMake generation string. Use separate add for arguments, as
+		 * they may contain spaces and additional quoting is not desired.
+		 */
+
+		File src = new File(context.getWorkspace().getRemote(), getWorkspace());
+		prepargs.add("-G" + getTargetSdk());
+		prepargs.add("-B" + getProjectDirectory().getRemote());
+		prepargs.add("-H" + src.getAbsolutePath());
+		prepargs.add("-DCMAKE_C_COMPILER=" + getClangCompilerExecutable());
+		prepargs.add("-DCMAKE_CXX_COMPILER=" + getClangXXCompilerExecutable());
+
+		String additionalBuildArgs = getAdditionalBuildArguments();
+		if (isNotBlank(additionalBuildArgs)) {
+			// This is a hack. I can't call the standard
+			// ArgumentListBuilder.add() method because it checks for spaces
+			// with-in
+			// the arg and quotes the arg if a space exists. Since user's can
+			// pass commands like
+			// '--use-cc=`which clang`' or multiple commands...we cannot allow
+			// the quotes to be
+			// inserted when spaces exist. The
+			// ArgumentListBuilder.addTokenized() splits the arg on spaces and
+			// adds each piece
+			// which ends up reinserting the spaces when the command is
+			// assembled.
+			prepargs.addTokenized(escapeSpacesInPath(additionalBuildArgs));
+		}
+
+		int rc = context.waitForProcess(getProjectDirectory(), prepargs);
+		if (rc == CommandExecutor.SUCCESS)
+			context.log("CMake successfully generated configuration.");
+		else {
+			context.log("CMake failed to generate configuration.");
+			return rc;
+		}
+
+		ArgumentListBuilder args = executeCommon(context);
+		args.add(getCMakeExecutable());
+
+		args.add("--build", getProjectDirectory().getRemote());
+		if (isNotBlank(getTarget())) {
+			args.add("--target", getTarget());
+		}
+		if (isNotBlank(getConfig()))
+			args.add("--config", getConfig());
+
+		rc = context.waitForProcess(getProjectDirectory(), args);
+
+		if (rc == CommandExecutor.SUCCESS) {
+			context.log("CMake SUCCESS");
+		} else {
+			context.log("CMake ERROR");
+		}
+
+		return rc;
+
+	}
+}

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanCMakeBuildCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanCMakeBuildCommand.java
@@ -15,15 +15,7 @@ public class ScanCMakeBuildCommand extends ScanBasicCommand {
 
 	public int execute(BuildContext context) throws Exception {
 
-		File build = new File(getProjectDirectory().toURI());
 		File src = new File(context.getWorkspace().getRemote(), getWorkspace());
-
-		/* Remove old build folder, but only if we build out of tree. */
-		if (!src.equals(build)) {
-			if (build.exists())
-				deleteFolder(build);
-			build.mkdirs();
-		}
 
 		/* Create the CMake configuration for the target. */
 		ArgumentListBuilder prepargs = new ArgumentListBuilder();
@@ -56,7 +48,7 @@ public class ScanCMakeBuildCommand extends ScanBasicCommand {
 			prepargs.addTokenized(escapeSpacesInPath(additionalBuildArgs));
 		}
 
-		int rc = context.waitForProcess(getProjectDirectory(), prepargs);
+		int rc = context.waitForProcess(context.getWorkspace(), prepargs);
 		if (rc == CommandExecutor.SUCCESS)
 			context.log("CMake successfully generated configuration.");
 		else {

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanMakeBuildCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/ScanMakeBuildCommand.java
@@ -1,0 +1,41 @@
+package jenkins.plugins.clangscanbuild.commands;
+
+import hudson.util.ArgumentListBuilder;
+import jenkins.plugins.clangscanbuild.CommandExecutor;
+
+public class ScanMakeBuildCommand extends ScanBasicCommand {
+	
+	public int execute( BuildContext context ) throws Exception {
+
+		ArgumentListBuilder args = executeCommon(context);
+		args.add( "make" );
+		
+		args.add( "clean" );
+		if( isNotBlank( getTarget() ) ){
+			args.add( getTarget() );
+		}else{
+			args.add( "all" );
+		}
+
+		String additionalBuildArgs = getAdditionalBuildArguments();
+		if( isNotBlank( additionalBuildArgs ) ){
+			// This is a hack.  I can't call the standard ArgumentListBuilder.add() method because it checks for spaces with-in
+			// the arg and quotes the arg if a space exists.  Since user's can pass commands like
+			// '--use-cc=`which clang`' or multiple commands...we cannot allow the quotes to be 
+			// inserted when spaces exist.  The ArgumentListBuilder.addTokenized() splits the arg on spaces and adds each piece 
+			// which ends up reinserting the spaces when the command is assembled.
+			args.addTokenized( additionalBuildArgs );
+		}
+
+		int rc = context.waitForProcess( getProjectDirectory(), args );
+
+		if( rc == CommandExecutor.SUCCESS ){
+			context.log( "MAKE SUCCESS" );
+		}else{
+			context.log( "MAKE ERROR" );
+		}
+		
+		return rc;
+
+	}
+}

--- a/src/main/java/jenkins/plugins/clangscanbuild/commands/XCodeSDKsCommand.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/commands/XCodeSDKsCommand.java
@@ -12,7 +12,7 @@ import java.io.PrintStream;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-public class XCodeSDKsCommand implements Command{
+public class XCodeSDKsCommand extends ScanBasicCommand {
 	
 	public int execute( BuildContext context ) {
 		return 1;

--- a/src/main/resources/index.jelly
+++ b/src/main/resources/index.jelly
@@ -1,4 +1,4 @@
 <div>
-  This plugin provides an new type of build-step and a publisher which can be used together to have an XCode project
-  statically analyzed using the Clang Static Analyzer.
+  This plugin provides an new type of build-step and a publisher which can be used together
+  to have a project statically analyzed using the Clang Static Analyzer.
 </div>

--- a/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/config.jelly
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/config.jelly
@@ -1,9 +1,9 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
-
-    <f:entry title="Build-Command" field="buildcommand">
-    		<f:textbox />
-  	</f:entry>
   	
+  	<f:entry field="buildcommand" title="Build-Toolchain">
+  		<f:select />
+	</f:entry>
+	    
     <f:entry title="Target" field="target">
     		<f:textbox />
   	</f:entry>

--- a/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/config.jelly
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/config.jelly
@@ -1,5 +1,9 @@
 <j:jelly xmlns:j="jelly:core" xmlns:st="jelly:stapler" xmlns:d="jelly:define" xmlns:l="/lib/layout" xmlns:t="/lib/hudson" xmlns:f="/lib/form">
 
+    <f:entry title="Build-Command" field="buildcommand">
+    		<f:textbox />
+  	</f:entry>
+  	
     <f:entry title="Target" field="target">
     		<f:textbox />
   	</f:entry>
@@ -38,7 +42,7 @@
     		<f:textbox default="" />
   		</f:entry>
 
-                <f:entry title="Additional xcode build arguments" field="xcodebuildargs">
+                <f:entry title="Additional build arguments" field="buildargs">
     		<f:textbox default="" />
   		</f:entry>
   		

--- a/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-buildargs.html
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-buildargs.html
@@ -1,0 +1,2 @@
+This field can be used to pass additional arguments to clang scan-build.  The arguments will appear after the build sub command.
+You can view the assembled command by viewing the job's build console.

--- a/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-buildcommand.html
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-buildcommand.html
@@ -1,0 +1,1 @@
+This field allows changing the build system used. Currently supported is XCode and custom build commands (e.g. make, CMake, ...)

--- a/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-projectSubPath.html
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-projectSubPath.html
@@ -1,0 +1,1 @@
+If your project is located in a sub-folder of this job's workspace, provide the path here relative to the workspace.  e.g. myProj/subfolder

--- a/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-xcodeProjectSubPath.html
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-xcodeProjectSubPath.html
@@ -1,1 +1,0 @@
-If your XCode project is located in a sub-folder of this job's workspace, provide the path here relative to the workspace.  e.g. myProj/subfolder

--- a/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-xcodebuildargs.html
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help-xcodebuildargs.html
@@ -1,2 +1,0 @@
-This field can be used to pass additional arguments to clang scan-build.  The arguments will appear after the xcodebuild sub command.
-You can view the assembled command by viewing the job's build console.

--- a/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help.html
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/help.html
@@ -1,1 +1,1 @@
-Use this option to execute clang scan-build against and XCode project.
+Use this option to execute clang scan-build.

--- a/src/test/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilderTest.java
+++ b/src/test/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilderTest.java
@@ -14,7 +14,7 @@ public class ClangScanBuildBuilderTest extends HudsonTestCase{
 		
 		FreeStyleProject p = createFreeStyleProject();
 		
-		ClangScanBuildBuilder builderBefore = new ClangScanBuildBuilder( "target", "sdk", "config", "installName", "projPath", "workspace", "scheme", "someargs", "somexcodeargs" );
+		ClangScanBuildBuilder builderBefore = new ClangScanBuildBuilder( "target", "sdk", "config", "installName", "projPath", "workspace", "xcode", "scheme", "someargs", "somexcodeargs" );
 		p.getBuildersList().add( builderBefore );
 
 		HtmlForm form = createWebClient().getPage( p, "configure" ).getFormByName( "config" );

--- a/src/test/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilderTest.java
+++ b/src/test/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilderTest.java
@@ -22,7 +22,7 @@ public class ClangScanBuildBuilderTest extends HudsonTestCase{
 
 		ClangScanBuildBuilder builderAfter = p.getBuildersList().get( ClangScanBuildBuilder.class );
 
-		assertEqualBeans( builderBefore, builderAfter, "target,config,targetSdk,xcodeProjectSubPath,workspace,scheme,scanbuildargs,xcodebuildargs" );
+		assertEqualBeans( builderBefore, builderAfter, "target,config,targetSdk,xcodeProjectSubPath,workspace,scheme,scanbuildargs,buildargs" );
 	}
 	
 }

--- a/src/test/java/jenkins/plugins/clangscanbuild/commands/ScanBuildCommandTest.java
+++ b/src/test/java/jenkins/plugins/clangscanbuild/commands/ScanBuildCommandTest.java
@@ -111,7 +111,7 @@ public class ScanBuildCommandTest{
 		command.setTarget( "myTarget" );
 		command.setTargetSdk( "myTargetSdk" );
 		command.setWorkspace( "myWorkspace" );
-		command.setAdditionalXcodeBuildArguments("VALID_ARCHS=i386" );
+		command.setAdditionalBuildArguments("VALID_ARCHS=i386" );
 
 		String actual = buildCommandAndReturn( command );
 		
@@ -153,7 +153,7 @@ public class ScanBuildCommandTest{
 		command.setTargetSdk( "myTargetSdk" );
 		command.setWorkspace( "myWorkspace" );
 		command.setAdditionalScanBuildArguments( "-h -x somevalue" );
-                command.setAdditionalXcodeBuildArguments("THIS=1 THAT=2");
+                command.setAdditionalBuildArguments("THIS=1 THAT=2");
 
 		String actual = buildCommandAndReturn( command );
 		

--- a/src/test/java/jenkins/plugins/clangscanbuild/commands/ScanBuildCommandTest.java
+++ b/src/test/java/jenkins/plugins/clangscanbuild/commands/ScanBuildCommandTest.java
@@ -19,7 +19,7 @@ public class ScanBuildCommandTest{
 	public void onlyRequiredOptionsSet() throws Exception{
 		ScanBuildCommand command = new ScanBuildCommand();
 		command.setClangOutputFolder( new FilePath( new File( "OutputFolder" ) ) );
-		command.setClangScanBuildPath( "/ScanBuild" );
+		command.setClangScanExecutable( "/ScanBuild" );
 		command.setProjectDirectory( new FilePath( new File( "/ProjectDir" ) ) );
 
 		String actual = buildCommandAndReturn( command );
@@ -33,7 +33,7 @@ public class ScanBuildCommandTest{
 		// XCode 4 workspace/scheme should override unnecessary target
 		ScanBuildCommand command = new ScanBuildCommand();
 		command.setClangOutputFolder( new FilePath( new File( "OutputFolder" ) ) );
-		command.setClangScanBuildPath( "/ScanBuild" );
+		command.setClangScanExecutable( "/ScanBuild" );
 		command.setConfig( "myConfig" );
 		command.setProjectDirectory( new FilePath( new File( "/ProjectDir" ) ) );
 		command.setScheme( "myScheme" );
@@ -52,7 +52,7 @@ public class ScanBuildCommandTest{
 		// XCode 4 workspace/scheme should override unnecessary target
 		ScanBuildCommand command = new ScanBuildCommand();
 		command.setClangOutputFolder( new FilePath( new File( "OutputFolder" ) ) );
-		command.setClangScanBuildPath( "/ScanBuild" );
+		command.setClangScanExecutable( "/ScanBuild" );
 		command.setConfig( "myConfig" );
 		command.setProjectDirectory( new FilePath( new File( "/ProjectDir" ) ) );
 		command.setTarget( "myTarget" );
@@ -83,7 +83,7 @@ public class ScanBuildCommandTest{
 		// XCode 4 workspace/scheme should override unnecessary target
 		ScanBuildCommand command = new ScanBuildCommand();
 		command.setClangOutputFolder( new FilePath( new File( "OutputFolder" ) ) );
-		command.setClangScanBuildPath( "/ScanBuild" );
+		command.setClangScanExecutable( "/ScanBuild" );
 		command.setConfig( "myConfig" );
 		command.setProjectDirectory( new FilePath( new File( "/ProjectDir" ) ) );
 		command.setScheme( "myScheme" );
@@ -104,7 +104,7 @@ public class ScanBuildCommandTest{
 		// XCode 4 workspace/scheme should override unnecessary target
 		ScanBuildCommand command = new ScanBuildCommand();
 		command.setClangOutputFolder( new FilePath( new File( "OutputFolder" ) ) );
-		command.setClangScanBuildPath( "/ScanBuild" );
+		command.setClangScanExecutable( "/ScanBuild" );
 		command.setConfig( "myConfig" );
 		command.setProjectDirectory( new FilePath( new File( "/ProjectDir" ) ) );
 		command.setScheme( "myScheme" );
@@ -125,7 +125,7 @@ public class ScanBuildCommandTest{
 		// XCode 4 workspace/scheme should override unnecessary target
 		ScanBuildCommand command = new ScanBuildCommand();
 		command.setClangOutputFolder( new FilePath( new File( "OutputFolder" ) ) );
-		command.setClangScanBuildPath( "/ScanBuild" );
+		command.setClangScanExecutable( "/ScanBuild" );
 		command.setConfig( "myConfig" );
 		command.setProjectDirectory( new FilePath( new File( "/ProjectDir" ) ) );
 		command.setScheme( "myScheme" );
@@ -145,7 +145,7 @@ public class ScanBuildCommandTest{
 		// XCode 4 workspace/scheme should override unnecessary target
 		ScanBuildCommand command = new ScanBuildCommand();
 		command.setClangOutputFolder( new FilePath( new File( "OutputFolder" ) ) );
-		command.setClangScanBuildPath( "/ScanBuild" );
+		command.setClangScanExecutable( "/ScanBuild" );
 		command.setConfig( "myConfig" );
 		command.setProjectDirectory( new FilePath( new File( "/ProjectDir" ) ) );
 		command.setScheme( "myScheme" );


### PR DESCRIPTION
These changes allow the selection of a build system different from XCode for clang analyzer.
The currently supported (but quite basic) options allow using CMake, Makefile and automake (configure must be available) based projects.

What should be changed:
* The workspace, target, ... fields should be named (and only shown) for the selected build toolchain.
* Currently it is not possible to add arguments for ```configure``` 
* CMake backend requires out of tree build, or the regeneration of CMake specific files may fail, if the toolchain changed.