### PR TITLE
Change applicability to AbstractProject

### DIFF
--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildDescriptor.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildDescriptor.java
@@ -100,7 +100,7 @@ public class ClangScanBuildDescriptor extends BuildStepDescriptor<Builder>{
     }
 
     public boolean isApplicable( @SuppressWarnings("rawtypes") Class<? extends AbstractProject> jobType ){
-        return FreeStyleProject.class.isAssignableFrom( jobType );
+        return AbstractProject.class.isAssignableFrom( jobType );
     }
     
 }


### PR DESCRIPTION
Changing the minimum level of isApplicable to AbstractProject from FreeStyleProject
allows the plugin to be used with other type of projects like the one generated by
the inheritance plugin at: https://wiki.jenkins-ci.org/display/JENKINS/inheritance-plugin