### PR TITLE
Update the publisher to copy all the available reports.

### DIFF
--- a/src/main/java/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction.java
@@ -33,7 +33,6 @@ public class ClangScanBuildAction implements Action, StaplerProxy, ModelObject{
 	private FilePath bugSummaryXML;
 	private boolean markBuildUnstable;
 	private int bugCount;
-	private AbstractBuild<?,?> build;
 	
 	private Pattern APPROVED_REPORT_REQUEST_PATTERN = Pattern.compile( "[^.\\\\/]*\\.html|StaticAnalyzer.*\\.html" );
 	
@@ -44,6 +43,8 @@ public class ClangScanBuildAction implements Action, StaplerProxy, ModelObject{
 		this.markBuildUnstable = markBuildUnstable;
 		this.build = build;
 	}
+
+	public AbstractBuild<?,?> build;
 	
 	public boolean buildFailedDueToExceededThreshold(){
 		if( !markBuildUnstable ) return false;

--- a/src/main/java/jenkins/plugins/clangscanbuild/history/ClangScanBuildBug.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/history/ClangScanBuildBug.java
@@ -7,6 +7,10 @@ public class ClangScanBuildBug {
 	public String bugType;
 	public String bugDescription;
 	public String bugCategory;
+	public String functionName;
+	public String bugLine;
+	public String bugColumn;
+	public String bugPathLength;
 	public boolean newBug;
 	
 	public boolean isNewBug() {
@@ -45,7 +49,31 @@ public class ClangScanBuildBug {
 	public void setSourceFile(String sourceFile) {
 		this.sourceFile = sourceFile;
 	}
-	
+	public String getFunctionName() {
+		return functionName;
+	}
+	public void setFunctionName(String functionName) {
+		this.functionName = functionName;
+	}
+	public String getBugLine() {
+		return bugLine;
+	}
+	public void setBugLine(String BugLine) {
+		this.bugLine = bugLine;
+	}
+	public String getBugColumn() {
+		return bugColumn;
+	}
+	public void setBugColumn(String bugColumn) {
+		this.bugColumn = bugColumn;
+	}
+	public String getBugPathLength() {
+		return bugPathLength;
+	}
+	public void setBugPathLength(String bugPathLength) {
+		this.bugPathLength = bugPathLength;
+	}
+
 	@Override
 	public int hashCode() {
 		final int prime = 31;

--- a/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher.java
@@ -176,7 +176,15 @@ public class ClangScanBuildPublisher extends Recorder{
 
 	/**
 	 * Clang always creates a subfolder within the specified output folder that has a unique name.
-	 * This method locates the first subfolder of the output folder and copies its contents
+         *
+         * The report summary uses all report-*.html files in the scan-build output folder to generate
+         * the bug entries. Scan build may generate multiple dated folders with reports in for a
+         * build.
+         *
+         * Only the reports in the build archive folder are published so it is therefore necessary
+         * to copy the reports from all the dated folders into the reports folder.
+         *
+	 * This method locates the subfolders of the output folder and copies their contents
 	 * to the build archive folder.
 	 */
 	private void copyClangReportsOutOfGeneratedSubFolder( FilePath reportsFolder, BuildListener listener ){
@@ -187,9 +195,10 @@ public class ClangScanBuildPublisher extends Recorder{
 				return;
 			}
 	
-			FilePath clangDateFolder = subFolders.get( 0 );
-			clangDateFolder.copyRecursiveTo( reportsFolder );
-			clangDateFolder.deleteRecursive();
+			for (FilePath clangDateFolder : subFolders) {
+                            clangDateFolder.copyRecursiveTo( reportsFolder );
+                            clangDateFolder.deleteRecursive();
+                        }
 		}catch( Exception e ){
 			listener.fatalError( "Unable to copy Clan scan-build output to build archive folder." );
 		}

--- a/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher.java
@@ -37,6 +37,10 @@ public class ClangScanBuildPublisher extends Recorder{
 	private static final Pattern BUG_DESC_PATTERN = Pattern.compile( "<!--\\sBUGDESC\\s(.*)\\s-->" );
 	private static final Pattern BUGFILE_PATTERN = Pattern.compile( "<!--\\sBUGFILE\\s(.*)\\s-->" );
 	private static final Pattern BUGCATEGORY_PATTERN = Pattern.compile( "<!--\\sBUGCATEGORY\\s(.*)\\s-->" );
+	private static final Pattern FUNCTIONNAME_PATTERN = Pattern.compile( "<!--\\sFUNCTONNAME\\s(.*)\\s-->" );
+	private static final Pattern BUGLINE_PATTERN = Pattern.compile( "<!--\\sBUGLINE\\s(.*)\\s-->" );
+	private static final Pattern BUGCOLUMN_PATTERN = Pattern.compile( "<!--\\sBUGCOLUMN\\s(.*)\\s-->" );
+	private static final Pattern BUGPATHLENGTH_PATTERN = Pattern.compile( "<!--\\sBUGPATHLENGTH\\s(.*)\\s-->" );
 
 	private int bugThreshold;
 	private String clangexcludedpaths; 
@@ -242,8 +246,12 @@ public class ClangScanBuildPublisher extends Recorder{
 			instance.setBugDescription( getMatch( BUG_DESC_PATTERN, contents ) );
 			instance.setBugType( getMatch( BUG_TYPE_PATTERN, contents ) );
 			instance.setBugCategory( getMatch( BUGCATEGORY_PATTERN, contents ) );
+                        instance.setFunctionName( getMatch( FUNCTIONNAME_PATTERN, contents ) );
+                        instance.setBugLine( getMatch( BUGLINE_PATTERN, contents ) );
+                        instance.setBugColumn( getMatch( BUGCOLUMN_PATTERN, contents ) );
+                        instance.setBugPathLength( getMatch( BUGPATHLENGTH_PATTERN, contents ) );
+
 			String sourceFile = getMatch( BUGFILE_PATTERN, contents );
-      
 
 			// This attempts to shorten the file path by removing the workspace path and
 			// leaving only the path relative to the workspace.

--- a/src/main/resources/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction/index.jelly
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction/index.jelly
@@ -3,7 +3,7 @@
 	<j:set var="bugSummary" value="${it.loadBugSummary()}"/>
 	
 	<l:layout title="Clang Scan-Build">
-
+	<st:include it="${it.build}" page="sidepanel.jelly"/>
     <l:main-panel>
     	<h2>Clang scan-build bug report for build #${bugSummary.buildNumber}</h2>
 	

--- a/src/main/resources/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction/index.jelly
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction/index.jelly
@@ -9,9 +9,10 @@
 	
 		<table border="1px" class="sortable pane">
 	      <tr>
+	        <td>Group</td>
+	        <td>Type</td>
 	      	<td>File</td>
-	        <td>Bug Type</td>
-	        <td>Category</td>
+		<td>Path Length</td>
 	        <td>Description</td>
 	        <td></td>	      
 	      </tr>
@@ -19,13 +20,16 @@
 	    <j:forEach var="bug" items="${bugSummary.bugs}">
 	      <tr style="${h.ifThenElse( bug.newBug,'background-color: #FCDEDE;','')}">
 	        <td>
-	          <st:out value="${bug.sourceFile}"/>
+	          <st:out value="${bug.bugCategory}"/>
 	        </td>
 	        <td>
 	          <st:out value="${bug.bugType}"/>
 	        </td>
 	        <td>
-	          <st:out value="${bug.bugCategory}"/>
+	          <st:out value="${bug.sourceFile}"/>
+	        </td>
+	        <td>
+	          <st:out value="${bug.bugPathLength}"/>
 	        </td>
 	        <td>
 	          <st:out value="${bug.bugDescription}"/>


### PR DESCRIPTION
The scan-build (when invoked with make) can create multiple output
subdirectories, the bug summary report generation correctly uses all
the available report files but the publisher was only making the
reports from one subdirectory available thus causing bad links from
the summary reports.