### PR TITLE
Fix null pointer exception in getClangexcludedpaths

### DIFF
--- a/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher.java
@@ -90,7 +90,10 @@ public class ClangScanBuildPublisher extends Recorder{
 	}
 
 	public String getClangexcludedpaths(){
-		return clangexcludedpaths;
+		if (clangexcludedpaths != null) {
+			return clangexcludedpaths;
+		}
+		return "";
 	}
 
 	@Override


### PR DESCRIPTION
If you do not use the build step, `clangexcludedpaths` can be `null`. But
it's still a valid use case to only use the publisher part of this
plugin.