### PR TITLE
Added support for configuration of report output directory in Builder and Publisher

### DIFF
--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
@@ -54,8 +54,8 @@ public class ClangScanBuildBuilder extends Builder{
     		String workspace,
     		String scheme,
     		String scanbuildargs,
-            String xcodebuildargs,
-			String outputFolderName){
+    		String xcodebuildargs,
+    		String outputFolderName){
     	
         this.target = Util.fixEmptyAndTrim( target );
         this.targetSdk = Util.fixEmptyAndTrim( targetSdk );

--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder.java
@@ -42,6 +42,7 @@ public class ClangScanBuildBuilder extends Builder{
     private String scheme;
     private String scanbuildargs;
     private String xcodebuildargs;
+	private String outputFolderName;
 
     @DataBoundConstructor
     public ClangScanBuildBuilder( 
@@ -53,7 +54,8 @@ public class ClangScanBuildBuilder extends Builder{
     		String workspace,
     		String scheme,
     		String scanbuildargs,
-                String xcodebuildargs){
+            String xcodebuildargs,
+			String outputFolderName){
     	
         this.target = Util.fixEmptyAndTrim( target );
         this.targetSdk = Util.fixEmptyAndTrim( targetSdk );
@@ -64,6 +66,7 @@ public class ClangScanBuildBuilder extends Builder{
         this.scheme = Util.fixEmptyAndTrim( scheme );
         this.scanbuildargs = Util.fixEmptyAndTrim( scanbuildargs );
         this.xcodebuildargs = Util.fixEmptyAndTrim( xcodebuildargs );
+		this.outputFolderName = Util.fixEmptyAndTrim( outputFolderName );
     }
 
     public String getClangInstallationName(){
@@ -96,6 +99,10 @@ public class ClangScanBuildBuilder extends Builder{
 
         public String getXcodebuildargs(){
 		return xcodebuildargs;
+	}
+
+	public String getOutputFolderName(){
+		return outputFolderName;
 	}
 
 	/**
@@ -135,7 +142,7 @@ public class ClangScanBuildBuilder extends Builder{
 		xcodebuild.setConfig( getConfig() );
 		xcodebuild.setAdditionalScanBuildArguments( getScanbuildargs() );
 		xcodebuild.setAdditionalXcodeBuildArguments( getXcodebuildargs() );
-		xcodebuild.setClangOutputFolder( new FilePath( build.getWorkspace(), ClangScanBuildUtils.REPORT_OUTPUT_FOLDERNAME) );
+		xcodebuild.setClangOutputFolder( new FilePath( build.getWorkspace(), getOutputFolderName()) );
 		xcodebuild.setWorkspace( getWorkspace() );
 		xcodebuild.setScheme( getScheme() );
 		

--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildUtils.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildUtils.java
@@ -16,9 +16,9 @@ public class ClangScanBuildUtils{
 		return "/plugin/" + PluginImpl.SHORTNAME + "/transparent.png";
 	}
 	
-	public static FilePath locateClangScanBuildReportFolder( AbstractBuild<?,?> build ){
+	public static FilePath locateClangScanBuildReportFolder( AbstractBuild<?,?> build, String folderName ){
 		if( build == null ) return null;
-		return new FilePath( new FilePath( build.getRootDir() ), REPORT_OUTPUT_FOLDERNAME );
+		return new FilePath( new FilePath( build.getRootDir() ), folderName );
 	}
 	
 }

--- a/src/main/java/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/actions/ClangScanBuildAction.java
@@ -33,15 +33,18 @@ public class ClangScanBuildAction implements Action, StaplerProxy, ModelObject{
 	private FilePath bugSummaryXML;
 	private boolean markBuildUnstable;
 	private int bugCount;
+	private String outputFolderName;
 	
 	private Pattern APPROVED_REPORT_REQUEST_PATTERN = Pattern.compile( "[^.\\\\/]*\\.html|StaticAnalyzer.*\\.html" );
 	
-	public ClangScanBuildAction( AbstractBuild<?,?> build, int bugCount, boolean markBuildUnstable, int bugThreshold, FilePath bugSummaryXML ){
+	public ClangScanBuildAction( AbstractBuild<?,?> build, int bugCount, boolean markBuildUnstable, 
+			int bugThreshold, FilePath bugSummaryXML, String outputFolderName ){
 		this.bugThreshold = bugThreshold;
 		this.bugCount = bugCount;
 		this.bugSummaryXML = bugSummaryXML;
 		this.markBuildUnstable = markBuildUnstable;
 		this.build = build;
+		this.outputFolderName = outputFolderName;
 	}
 
 	public AbstractBuild<?,?> build;
@@ -140,7 +143,7 @@ public class ClangScanBuildAction implements Action, StaplerProxy, ModelObject{
     		return;
     	}
     	
-    	FilePath reports = ClangScanBuildUtils.locateClangScanBuildReportFolder( build );
+    	FilePath reports = ClangScanBuildUtils.locateClangScanBuildReportFolder( build, outputFolderName );
     	FilePath requestedFile = new FilePath( reports, trimFirstSlash( requestedPath ) );
     	
     	try{

--- a/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher.java
@@ -114,10 +114,10 @@ public class ClangScanBuildPublisher extends Recorder{
 		
 		// Expand build variables in the reportFolderName
 		EnvVars env = build.getEnvironment(listener);
-		reportFolderName = env.expand(reportFolderName);
+		String expandedReportFolderName = env.expand(reportFolderName);
 		
-		FilePath reportOutputFolder = new FilePath(build.getWorkspace(), reportFolderName); 
-		FilePath reportMasterOutputFolder = ClangScanBuildUtils.locateClangScanBuildReportFolder(build, reportFolderName);
+		FilePath reportOutputFolder = new FilePath(build.getWorkspace(), expandedReportFolderName); 
+		FilePath reportMasterOutputFolder = ClangScanBuildUtils.locateClangScanBuildReportFolder(build, expandedReportFolderName);
 		
 		// This copies the reports out of the generate date sub folder to the root of the reports folder and then deletes the clang generated folder
 		copyClangReportsOutOfGeneratedSubFolder( reportOutputFolder, listener );
@@ -163,7 +163,7 @@ public class ClangScanBuildPublisher extends Recorder{
 		bugSummaryXMLFile.write( bugSummaryXML, "UTF-8" );
 		
 		// this adds a build actions which records the bug count into the build results.  This count is used to generate the trend charts
-		final ClangScanBuildAction action = new ClangScanBuildAction( build, newBugSummary.getBugCount(), markBuildUnstableWhenThresholdIsExceeded, bugThreshold, bugSummaryXMLFile, reportFolderName );
+		final ClangScanBuildAction action = new ClangScanBuildAction( build, newBugSummary.getBugCount(), markBuildUnstableWhenThresholdIsExceeded, bugThreshold, bugSummaryXMLFile, expandedReportFolderName );
         build.getActions().add( action );
 
         // this checks if the build should be failed due to an increase in bugs

--- a/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisherDescriptor.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisherDescriptor.java
@@ -1,5 +1,6 @@
 package jenkins.plugins.clangscanbuild.publisher;
 
+import jenkins.plugins.clangscanbuild.ClangScanBuildUtils;
 import net.sf.json.JSONObject;
 
 import org.kohsuke.stapler.StaplerRequest;
@@ -17,12 +18,14 @@ public class ClangScanBuildPublisherDescriptor extends BuildStepDescriptor<Publi
 		load();
 	}
 	
+	
 	@Override
 	public Publisher newInstance(StaplerRequest arg0, JSONObject json ) throws hudson.model.Descriptor.FormException {
 
 		boolean markBuildUnstable = false;
 		int bugThreshold = 0;
 		String excludedPaths = "";
+		String reportFolderName = ClangScanBuildUtils.REPORT_OUTPUT_FOLDERNAME;
 		
 		JSONObject failWhenThresholdExceeded = json.optJSONObject( "failWhenThresholdExceeded" );
 		if( failWhenThresholdExceeded != null ){
@@ -30,8 +33,10 @@ public class ClangScanBuildPublisherDescriptor extends BuildStepDescriptor<Publi
 			bugThreshold = failWhenThresholdExceeded.getInt( "bugThreshold" );
 			excludedPaths = failWhenThresholdExceeded.getString( "clangexcludedpaths" );
 		}
+		
+		reportFolderName = json.getString("reportFolderName");
     		
-		return new ClangScanBuildPublisher( markBuildUnstable, bugThreshold, excludedPaths );
+		return new ClangScanBuildPublisher( markBuildUnstable, bugThreshold, excludedPaths, reportFolderName );
 	}
 	
 	@Override

--- a/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/config.jelly
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/ClangScanBuildBuilder/config.jelly
@@ -43,5 +43,9 @@
   		</f:entry>
   		
 	</f:advanced>
+
+	<f:entry title="Output Folder" field="outputFolderName">
+		<f:textbox default="clangScanBuildReports"/>
+	</f:entry>
   	
 </j:jelly>

--- a/src/main/resources/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher/config.jelly
+++ b/src/main/resources/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisher/config.jelly
@@ -11,8 +11,14 @@
 		    <f:entry title="Paths to exclude from bug reports" field="clangexcludedpaths">
 					<f:textbox />
 			</f:entry>
+
 	      
 	    </f:optionalBlock>
+	    
+	    <f:entry title="Report folder" field="reportFolderName">
+				<f:textbox default="clangScanBuildReports"/>
+		</f:entry>
+	    
 	  </table>
    </f:nested>
   	

--- a/src/test/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilderTest.java
+++ b/src/test/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilderTest.java
@@ -14,7 +14,8 @@ public class ClangScanBuildBuilderTest extends HudsonTestCase{
 		
 		FreeStyleProject p = createFreeStyleProject();
 		
-		ClangScanBuildBuilder builderBefore = new ClangScanBuildBuilder( "target", "sdk", "config", "installName", "projPath", "workspace", "scheme", "someargs", "somexcodeargs" );
+		ClangScanBuildBuilder builderBefore = new ClangScanBuildBuilder( "target", "sdk", "config", 
+				"installName", "projPath", "workspace", "scheme", "someargs", "somexcodeargs", "outputfoldername" );
 		p.getBuildersList().add( builderBefore );
 
 		HtmlForm form = createWebClient().getPage( p, "configure" ).getFormByName( "config" );
@@ -22,7 +23,7 @@ public class ClangScanBuildBuilderTest extends HudsonTestCase{
 
 		ClangScanBuildBuilder builderAfter = p.getBuildersList().get( ClangScanBuildBuilder.class );
 
-		assertEqualBeans( builderBefore, builderAfter, "target,config,targetSdk,xcodeProjectSubPath,workspace,scheme,scanbuildargs,xcodebuildargs" );
+		assertEqualBeans( builderBefore, builderAfter, "target,config,targetSdk,xcodeProjectSubPath,workspace,scheme,scanbuildargs,xcodebuildargs,outputfoldername" );
 	}
 	
 }

--- a/src/test/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilderTest.java
+++ b/src/test/java/jenkins/plugins/clangscanbuild/ClangScanBuildBuilderTest.java
@@ -15,7 +15,7 @@ public class ClangScanBuildBuilderTest extends HudsonTestCase{
 		FreeStyleProject p = createFreeStyleProject();
 		
 		ClangScanBuildBuilder builderBefore = new ClangScanBuildBuilder( "target", "sdk", "config", 
-				"installName", "projPath", "workspace", "scheme", "someargs", "somexcodeargs", "outputfoldername" );
+				"installName", "projPath", "workspace", "scheme", "someargs", "somexcodeargs", "someoutputfoldername" );
 		p.getBuildersList().add( builderBefore );
 
 		HtmlForm form = createWebClient().getPage( p, "configure" ).getFormByName( "config" );
@@ -23,7 +23,7 @@ public class ClangScanBuildBuilderTest extends HudsonTestCase{
 
 		ClangScanBuildBuilder builderAfter = p.getBuildersList().get( ClangScanBuildBuilder.class );
 
-		assertEqualBeans( builderBefore, builderAfter, "target,config,targetSdk,xcodeProjectSubPath,workspace,scheme,scanbuildargs,xcodebuildargs,outputfoldername" );
+		assertEqualBeans( builderBefore, builderAfter, "target,config,targetSdk,xcodeProjectSubPath,workspace,scheme,scanbuildargs,xcodebuildargs,outputFolderName" );
 	}
 	
 }

--- a/src/test/java/jenkins/plugins/clangscanbuild/history/ClangScanBuildHistoryGathererImplTest.java
+++ b/src/test/java/jenkins/plugins/clangscanbuild/history/ClangScanBuildHistoryGathererImplTest.java
@@ -22,9 +22,9 @@ public class ClangScanBuildHistoryGathererImplTest extends HudsonTestCase{
 		FreeStyleProject project = createFreeStyleProject( "Test Project" );
 		
 		// The test instance is set to a threshold of 5...builds 2 and 7 should be excluded
-		performBuildWithClangAction( project, 1 );
+		performBuildWithClangAction( project, 1, "outputFolderName-1" );
 		performBuildWithOutClangAction( project );
-		FreeStyleBuild lastBuild = performBuildWithClangAction( project, 3 );
+		FreeStyleBuild lastBuild = performBuildWithClangAction( project, 3, "outputFolderName-3" );
 
 		List<GraphPoint> summaries = classUnderTest.gatherHistoryDataSet( lastBuild );
 	
@@ -35,7 +35,7 @@ public class ClangScanBuildHistoryGathererImplTest extends HudsonTestCase{
 	public void testFirstBuildDoesNotFail() throws Exception{
 		FreeStyleProject project = createFreeStyleProject( "Test Project" );
 		
-		FreeStyleBuild build1 = performBuildWithClangAction( project, 1 );
+		FreeStyleBuild build1 = performBuildWithClangAction( project, 1, "outputFolderName-1" );
 		
 		List<GraphPoint> summaries = classUnderTest.gatherHistoryDataSet( build1 );
 		
@@ -44,15 +44,15 @@ public class ClangScanBuildHistoryGathererImplTest extends HudsonTestCase{
 	
 	private class TestClangScanBuildAction extends ClangScanBuildAction{
 
-		public TestClangScanBuildAction( AbstractBuild<?,?> build, int bugCount, int threshold ){
-			super( build, bugCount, true, threshold, null );
+		public TestClangScanBuildAction( AbstractBuild<?,?> build, int bugCount, int threshold, String outputFolderName ){
+			super( build, bugCount, true, threshold, null, outputFolderName );
 		}
 
 	}
 	
-	private FreeStyleBuild performBuildWithClangAction( FreeStyleProject project, int bugCount ) throws Exception {
+	private FreeStyleBuild performBuildWithClangAction( FreeStyleProject project, int bugCount, String outputFolderName ) throws Exception {
 		FreeStyleBuild build = project.scheduleBuild2(0).get();
-		build.addAction( new TestClangScanBuildAction( build, bugCount, 0 ) );
+		build.addAction( new TestClangScanBuildAction( build, bugCount, 0, outputFolderName ) );
 		return build;
 	}
 	

--- a/src/test/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisherTest.java
+++ b/src/test/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisherTest.java
@@ -14,7 +14,7 @@ public class ClangScanBuildPublisherTest extends HudsonTestCase{
 		
 		FreeStyleProject p = createFreeStyleProject();
 		
-		ClangScanBuildPublisher publisherBefore = new ClangScanBuildPublisher( true, 45, "Pods", "reportfoldername");
+		ClangScanBuildPublisher publisherBefore = new ClangScanBuildPublisher( true, 45, "Pods", "somereportfoldername");
 		p.getPublishersList().add( publisherBefore );
 
 		HtmlForm form = createWebClient().getPage( p, "configure" ).getFormByName( "config" );
@@ -22,7 +22,7 @@ public class ClangScanBuildPublisherTest extends HudsonTestCase{
 
 		ClangScanBuildPublisher publisherAfter = p.getPublishersList().get( ClangScanBuildPublisher.class );
 
-		assertEqualBeans( publisherBefore, publisherAfter, "bugThreshold,markBuildUnstableWhenThresholdIsExceeded,clangexcludedpaths,reportfoldername" );
+		assertEqualBeans( publisherBefore, publisherAfter, "bugThreshold,markBuildUnstableWhenThresholdIsExceeded,clangexcludedpaths,reportFolderName" );
 	}
 	
 }

--- a/src/test/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisherTest.java
+++ b/src/test/java/jenkins/plugins/clangscanbuild/publisher/ClangScanBuildPublisherTest.java
@@ -14,7 +14,7 @@ public class ClangScanBuildPublisherTest extends HudsonTestCase{
 		
 		FreeStyleProject p = createFreeStyleProject();
 		
-		ClangScanBuildPublisher publisherBefore = new ClangScanBuildPublisher( true, 45, "Pods" );
+		ClangScanBuildPublisher publisherBefore = new ClangScanBuildPublisher( true, 45, "Pods", "reportfoldername");
 		p.getPublishersList().add( publisherBefore );
 
 		HtmlForm form = createWebClient().getPage( p, "configure" ).getFormByName( "config" );
@@ -22,7 +22,7 @@ public class ClangScanBuildPublisherTest extends HudsonTestCase{
 
 		ClangScanBuildPublisher publisherAfter = p.getPublishersList().get( ClangScanBuildPublisher.class );
 
-		assertEqualBeans( publisherBefore, publisherAfter, "bugThreshold,markBuildUnstableWhenThresholdIsExceeded,clangexcludedpaths" );
+		assertEqualBeans( publisherBefore, publisherAfter, "bugThreshold,markBuildUnstableWhenThresholdIsExceeded,clangexcludedpaths,reportfoldername" );
 	}
 	
 }


### PR DESCRIPTION
Hi Joshua,

Please consider some changes that should resolve the issue of configuring the directories where the reports are placed and read.

(https://issues.jenkins-ci.org/browse/JENKINS-18941?jql=project%20%3D%20JENKINS%20AND%20status%20in%20(Open%2C%20"In%20Progress"%2C%20Reopened)%20AND%20component%20%3D%20%27clang-scanbuild-plugin%27)

The issue has been bothering me a bit, so I thought I'd have a go at resolving it.

Best regards and thanks for the plugin!

Maarten

PS I forked from jenkinsci upstream, not from joshua1980, as the former was the one specified in the Jenkins plugin doc. 




