### PR TITLE
[JENKINS-40236] Fixed shortname string to match project

### DIFF
--- a/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildUtils.java
+++ b/src/main/java/jenkins/plugins/clangscanbuild/ClangScanBuildUtils.java
@@ -26,7 +26,7 @@ import hudson.model.AbstractBuild;
 
 
 public class ClangScanBuildUtils{
-	public static final String SHORTNAME = "clang-scanbuild-plugin";
+	public static final String SHORTNAME = "clang-scanbuild";
 	public static final String REPORT_OUTPUT_FOLDERNAME = "clangScanBuildReports";
 	
 	public static String getIconsPath(){


### PR DESCRIPTION
Modified the SHORTNAME static string from ClangScanBuildUtils.java to match the project one in build.gradle

It seems "-plugin" was dropped from the name but missed here.